### PR TITLE
Do not shrink underlying arrays on pop/clear

### DIFF
--- a/index.mjs
+++ b/index.mjs
@@ -8,14 +8,14 @@ export default class FlatQueue {
     }
 
     clear() {
-        this.length = this.ids.length = this.values.length = 0;
+        this.length = 0;
     }
 
     push(id, value) {
-        this.ids.push(id);
-        this.values.push(value);
-
         let pos = this.length++;
+        this.ids[pos] = id;
+        this.values[pos] = value;
+
         while (pos > 0) {
             const parent = (pos - 1) >> 1;
             const parentValue = this.values[parent];
@@ -63,9 +63,6 @@ export default class FlatQueue {
             this.ids[pos] = id;
             this.values[pos] = value;
         }
-
-        this.ids.pop();
-        this.values.pop();
 
         return top;
     }


### PR DESCRIPTION
By avoiding shrinking arrays on pop or clear, and only keeping track of the length used and overwriting values beyond, we can optimize the use case when the queue is repeatedly reused (like Flatbush https://github.com/mourner/flatbush/issues/27), while not really affecting performance much for other cases.