### PR TITLE
Remove redundant array assignments

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,8 +13,6 @@ export default class FlatQueue {
 
     push(id, value) {
         let pos = this.length++;
-        this.ids[pos] = id;
-        this.values[pos] = value;
 
         while (pos > 0) {
             const parent = (pos - 1) >> 1;


### PR DESCRIPTION
Hello! Thanks for writing this package.

I noticed that the code for `push` assigned to `this.ids` and `this.values` twice, both before and after the sift loop.

This PR removes the extra assignments and passes tests.
